### PR TITLE
Implement subscribe sample for the gnmi simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# simulators
+# Simulators
 [![Build Status](https://travis-ci.org/onosproject/simulators.svg?branch=master)](https://travis-ci.org/onosproject/simulators)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/gojp/goreportcard/blob/master/LICENSE)
 [![GoDoc](https://godoc.org/github.com/onosproject/simulators?status.svg)](https://godoc.org/github.com/onosproject/simulators)
@@ -10,3 +10,7 @@ Simple simulators, used for integration testing of ONOS interactions with device
 - Shaping pipelines and controlling traffic flow via P4 programs and P4Runtime
 
 The simulator facilities are available as Go package libraries, executable commands and as published Docker containers.
+
+# Additional Documentation
+
+[How to run](docs/README.md) device simulator and related commands.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,17 @@
-# Device Simulator
+**Table of Contents**
+
+- [1. Device Simulator](#1-Device-Simulator)
+  - [1.1. Simulator mode](#11-Simulator-mode)
+  - [1.2. Run mode - localhost or network](#12-Run-mode---localhost-or-network)
+  - [1.3. docker-compose](#13-docker-compose)
+    - [1.3.1. Running on Linux](#131-Running-on-Linux)
+  - [1.4. Run a single docker container](#14-Run-a-single-docker-container)
+  - [1.5. Create the docker image](#15-Create-the-docker-image)
+- [2. Client tools for testing](#2-Client-tools-for-testing)
+  - [2.1. gNMI Client User Manual](#21-gNMI-Client-User-Manual)
+  - [2.2. gNOI Client User Manual](#22-gNOI-Client-User-Manual)
+  
+# 1. Device Simulator
 
 This is a docker VM that runs a gNMI and/or gNOI implementation 
 supporting openconfig models.
@@ -7,14 +20,14 @@ Inspired by https://github.com/faucetsdn/gnmi
 
 All commands below assume you are in the __devicesim__ directory
 
-## Simulator mode
+## 1.1. Simulator mode
 The device simulator can operate in three modes, controlled
 using **SIM_MODE** environment variable in the docker-compose file. 
 1) SIM_MODE=1 as gNMI target only. The configuration is loaded by default from [configs/target_configs/typical_ofsw_config.json](../configs/target_configs/typical_ofsw_config.json)
 2) SIM_MODE=2 as gNOI target only. It supports *Certificate management* that can be used for certificate installation and rotation. 
 3) SIM_MODE=3 both gNMI and gNOsI targets simultaneously
 
-## Run mode - localhost or network
+## 1.2. Run mode - localhost or network
 Additionally the simulator can be run in
 * localhost mode - use on Docker for Mac, Windows or Linux
 * dedicated network mode - for use on Linux only 
@@ -22,7 +35,7 @@ Additionally the simulator can be run in
 > Docker for Mac or Windows does not support accessing docker images
 > externally in dedicated network mode. Docker on Linux can run either.
 
-## docker-compose
+## 1.3. docker-compose
 Docker compose manages the running of several docker images at once.
 
 For example to run 3 **SIM_MODE=1** (gNMI only devices) and **localhost** mode, use: 
@@ -47,7 +60,7 @@ devicesim1_1  | gNMI running on localhost:10161
 > Use the -d mode with docker-compose to make it run as a daemon in the background
 
 
-### Running on Linux
+### 1.3.1. Running on Linux
 If you are fortunate enough to be using Docker on Linux, then you can use the
 above method __or__ using the command below to start in **SIM_MODE=1** and **network** mode:
 
@@ -72,7 +85,7 @@ device1-3. An entry must still be placed in your /etc/hosts file for all 3 like:
 > the cluster, so either the entries have to be placed in /etc/hosts or on some
 > DNS server
 
-## Run a single docker container
+## 1.4. Run a single docker container
 If you just want to run a single device, it is not necessary to run 
 docker-compose. It can be done just by docker directly, and can be 
 handy for troubleshooting. The following command shows how to run
@@ -84,18 +97,19 @@ docker run --env "HOSTNAME=localhost" --env "SIM_MODE=3" \
 ```
 To stop it use "docker kill"
 
-## Create the docker image
+## 1.5. Create the docker image
 By default the docker compose command will pull down the latest docker
 image from the Docker Hub. If you need to build it locally, run:
 ```bash
 docker build -t onosproject/device-simulator:stable -f Dockerfile .
 ```
 
-# Client tools for testing
+# 2. Client tools for testing
 You can access to the information about client tools for each SIM_MODE
 including troubleshooting tips using the following links: 
 
+## 2.1. gNMI Client User Manual
 [gNMI Client_User Manual](gnmi/gnmi_user_manual.md)
 
+## 2.2. gNOI Client User Manual
 [gNOI Client_User Manual](gnoi/gnoi_user_manual.md)
-

--- a/docs/gnoi/gnoi_user_manual.md
+++ b/docs/gnoi/gnoi_user_manual.md
@@ -1,6 +1,12 @@
-# gNOI Client Simulator User Manual
+**Table of Content**
+- [1. How to test the gNOI simulator?](#1-How-to-test-the-gNOI-simulator)
+  - [1.1. How to install gNOI_cert on your machine?](#11-How-to-install-gNOIcert-on-your-machine)
+- [2. Troubleshooting](#2-Troubleshooting)
+  - [2.1. Connection Refused](#21-Connection-Refused)
+  - [2.2. TCP diagnosis](#22-TCP-diagnosis)
+  - [2.3. HTTP Diagnosis](#23-HTTP-Diagnosis)
 
-## How to test the gNOI simulator? 
+# 1. How to test the gNOI simulator? 
 1. First you should  ssh into any of the targets using the following command:
 ```bash
 sudo docker exec -it <Container_ID> /bin/bash
@@ -49,16 +55,16 @@ and the the server should report a success message:
 devicesim1_1  | I0429 15:45:00.909347      10 server.go:292] Success GetCertificates.
 ```
 
-### How to install gNOI_cert on your machine? 
+## 1.1. How to install gNOI_cert on your machine? 
 To install **gnoi_cert** on your own machine, you can use the following command: 
 ```bash
 go get -u github.com/google/gnxi/gnoi_cert
 go install -v github.com/google/gnxi/gnoi_cert
 ```
 
-## Troubleshooting
+# 2. Troubleshooting
 
-### Connection Refused
+## 2.1. Connection Refused
 If you get an error like
 ```bash
 F0501 15:32:50.313449      30 gnoi_cert.go:220] Failed GetCertificates:rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = "transport: Error while dialing dial tcp 127.0.0.1:50001: connect: connection refused"
@@ -66,7 +72,7 @@ F0501 15:32:50.313449      30 gnoi_cert.go:220] Failed GetCertificates:rpc error
 That means the gNOI target is not running or you are provding wrong ip:port information to the gnoi_cert command. 
 
 
-#### TCP diagnosis
+## 2.2. TCP diagnosis
 > This is not a concern with port mapping method using localhost and is for 
 > the Linux specific option only
 
@@ -81,7 +87,7 @@ Starting with TCP - see if you can ping the device
 For the last 2 cases make sure that the IP address that is resolved matches what
 was given at the startup of the simulator with docker.
 
-#### HTTP Diagnosis
+## 2.3. HTTP Diagnosis
 If TCP shows reachability then try with HTTPS - it's very important to remember
 that for HTTPS the address at which you access the server **must** match exactly
 the server name in the server key's Common Name (CN) like __localhost__ or

--- a/pkg/gnmi/defs.go
+++ b/pkg/gnmi/defs.go
@@ -59,14 +59,16 @@ type Server struct {
 }
 
 var (
-	readOnlyPath        = `elem:<name:"system" > elem:<name:"openflow" > elem:<name:"controllers" > elem:<name:"controller" key:<key:"name" value:"main" > > elem:<name:"connections" > elem:<name:"connection" key:<key:"aux-id" value:"0" > > elem:<name:"state" > elem:<name:"address" > `
-	randomEventInterval = time.Duration(5) * time.Second
+	readOnlyPath                = `elem:<name:"system" > elem:<name:"openflow" > elem:<name:"controllers" > elem:<name:"controller" key:<key:"name" value:"main" > > elem:<name:"connections" > elem:<name:"connection" key:<key:"aux-id" value:"0" > > elem:<name:"state" > elem:<name:"address" > `
+	randomEventInterval         = time.Duration(5) * time.Second
+	lowestSampleInterval uint64 = 5000000000 // 5000000000 nanoseconds
 )
 
 type streamClient struct {
-	target     string
-	sr         *pb.SubscribeRequest
-	stream     pb.GNMI_SubscribeServer
-	errChan    chan error
-	UpdateChan chan *pb.Update
+	target         string
+	sr             *pb.SubscribeRequest
+	stream         pb.GNMI_SubscribeServer
+	errChan        chan error
+	UpdateChan     chan *pb.Update
+	sampleInterval uint64
 }


### PR DESCRIPTION
@Andrea-Campanella @tomikazi 
This PR addresses the following items and issues #57 #58 #59  : 

1- We should distinguish different types of subscribe stream modes (i.e. ON_CHANGE, SAMPLE, TARGET_DEFINED). 

2- Implement subscribe sample excluding the optional part. 

3- Update the README files to include a TOC. 

4- For now, we define TARGET_DEFINED mode  to behave like ON_CHANGE mode but a better combination of ON_CHANGE and SAMPLE is needed based on gnmi spec. 