### PR TITLE
Removed cert alt name which had been added in for onos-gui

### DIFF
--- a/pkg/certs/generate_certs.sh
+++ b/pkg/certs/generate_certs.sh
@@ -32,7 +32,7 @@ openssl req \
         -newkey rsa:2048 \
         -nodes \
         -keyout ${DEVICE}.key \
-	-noout \
+	      -noout \
         -subj $SUBJ \
 	 > /dev/null 2>&1
 
@@ -51,7 +51,7 @@ openssl x509 \
         -CAkey onfca.key \
         -CAcreateserial \
         -days 3650 \
-        -sha256 -extfile v3.ext \
+        -sha256 \
         -out ${DEVICE}.crt \
 	 > /dev/null 2>&1
 


### PR DESCRIPTION
Removed the -extfile v3.ext
This had been put in to create a cert for onos-gui that would work with a browser, but it breaks all other certs so taking it out until onos-gui needs an SSL cert again