### PR TITLE
Add commit hashes to 'go get' commands in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ONOS_BUILD_VERSION=stable
-FROM golang:1.11-alpine AS build
+FROM golang:1.13-alpine AS build
 LABEL maintainer="Sean Condon <sean@opennetworking.org>, Adib Rastegarnia <adib@opennetworking.org> "
 LABEL description="Builds a gNMI/gNOI simulator on a Debian distribution"
 
@@ -20,23 +20,13 @@ RUN apk add \
 
 
 RUN mkdir -p $GOPATH \
-    && go get -u \
-      github.com/google/gnxi/gnmi_capabilities \
-      github.com/google/gnxi/gnmi_get \
-      github.com/google/gnxi/gnmi_set \
-      github.com/openconfig/gnmi/cmd/gnmi_cli \
-      github.com/google/gnxi/gnoi_target \ 
-      github.com/google/gnxi/gnoi_cert 
-      
-
-RUN go install -v \
-      github.com/google/gnxi/gnmi_capabilities \
-      github.com/google/gnxi/gnmi_get \
-      github.com/google/gnxi/gnmi_set \
-      github.com/openconfig/gnmi/cmd/gnmi_cli \
-      github.com/google/gnxi/gnoi_target \ 
-      github.com/google/gnxi/gnoi_cert
-
+    && GO111MODULE=on go get -u \
+      github.com/google/gnxi/gnmi_capabilities@6697a080bc2d3287d9614501a3298b3dcfea06df \
+      github.com/google/gnxi/gnmi_get@6697a080bc2d3287d9614501a3298b3dcfea06df \
+      github.com/google/gnxi/gnmi_set@6697a080bc2d3287d9614501a3298b3dcfea06df \
+      github.com/openconfig/gnmi/cmd/gnmi_cli@89b2bf29312cda887da916d0f3a32c1624b7935f \
+      github.com/google/gnxi/gnoi_target@6697a080bc2d3287d9614501a3298b3dcfea06df \ 
+      github.com/google/gnxi/gnoi_cert@6697a080bc2d3287d9614501a3298b3dcfea06df 
 
 ENV ONOS_SIMULATORS_ROOT=$GOPATH/src/github.com/onosproject/simulators
 ENV GO111MODULE=off
@@ -47,8 +37,8 @@ RUN mkdir -p $ONOS_SIMULATORS_ROOT/
 COPY cmd/ $GOPATH/src/github.com/onosproject/simulators/cmd/
 COPY pkg/ $GOPATH/src/github.com/onosproject/simulators/pkg/
 
-
-RUN cd $GOPATH/src/github.com/onosproject/simulators/cmd/gnmi_target && go install
+RUN cd $GOPATH/src/github.com/onosproject/simulators && \
+    GO111MODULE=on go get github.com/onosproject/simulators/cmd/gnmi_target
 
 FROM alpine:3.9
 RUN apk add --update bash openssl curl && rm -rf /var/cache/apk/*
@@ -67,5 +57,4 @@ COPY tools/scripts scripts
 COPY pkg/certs certs
 
 RUN chmod +x ./scripts/run_targets.sh
-
 CMD ["./scripts/run_targets.sh"]


### PR DESCRIPTION
Add commit hashes to `go get` commands to avoid unwanted dependency conflicts. Use Go modules when building `gnmi_target` to ensure dependencies are isolated.